### PR TITLE
Preserve surrounding tokens in macro expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ double pi_if_a_greater_b(double a, double b) {                &nbsp;
 </pre></sub></td>
 <td><sub><pre lang="cpp">
 double pi_if_a_greater_b(double a, double b) {                        &nbsp;
-  auto greater = a > b ? a : b;
+  auto greater = (a) > (b) ? (a) : (b);
   if (greater == a) {
     return 3.14;
   }

--- a/clang-expand.cpp
+++ b/clang-expand.cpp
@@ -51,6 +51,10 @@
 #include <string>
 #include <vector>
 
+#if defined(_MSC_VER)
+#pragma comment(lib, "version.lib")
+#endif
+
 namespace {
 llvm::cl::OptionCategory clangExpandCategory("clang-expand options");
 

--- a/include/clang-expand/definition-search/tool-factory.hpp
+++ b/include/clang-expand/definition-search/tool-factory.hpp
@@ -55,7 +55,7 @@ class ToolFactory : public clang::tooling::FrontendActionFactory {
 
   /// Creates the action of the definition search phase.
   /// \returns A `DefinitionSearch::Action`.
-  clang::FrontendAction* create() override;
+  std::unique_ptr<clang::FrontendAction> create() override;
 
  private:
   /// The file in which the declaration was found.

--- a/include/clang-expand/symbol-search/action.hpp
+++ b/include/clang-expand/symbol-search/action.hpp
@@ -80,8 +80,7 @@ class Action : public clang::ASTFrontendAction {
 
   /// Attempts to translate the `targetLocation` to a `clang::SourceLocation`
   /// and install preprocessor hooks for macros.
-  bool BeginSourceFileAction(clang::CompilerInstance& compiler,
-                             llvm::StringRef filename) override;
+  bool BeginSourceFileAction(clang::CompilerInstance& compiler) override;
 
   /// \returns a `SymbolSearch::Consumer`.
   ASTConsumerPointer CreateASTConsumer(clang::CompilerInstance& compiler,

--- a/include/clang-expand/symbol-search/tool-factory.hpp
+++ b/include/clang-expand/symbol-search/tool-factory.hpp
@@ -51,7 +51,7 @@ class ToolFactory : public clang::tooling::FrontendActionFactory {
 
   /// Creates the action of the symbol search phase.
   /// \returns A `SymbolSearch::Action`.
-  clang::FrontendAction* create() override;
+  std::unique_ptr<clang::FrontendAction> create() override;
 
  private:
   /// The location at which the user invoked clang-expand.

--- a/source/common/assignee-data.cpp
+++ b/source/common/assignee-data.cpp
@@ -74,11 +74,10 @@ bool AssigneeData::isDefaultConstructible() const noexcept {
 
 std::string AssigneeData::toAssignment(bool withType) const {
   if (withType && type.hasValue()) {
-    assert(type.hasValue() &&
-           "Requested assignee string with type, but have no type");
     return (llvm::Twine(type->name) + " " + name + " " + op).str();
+  } else {
+    return (llvm::Twine(name) + " " + op).str();
   }
-  return (llvm::Twine(name) + " " + op).str();
 }
 
 std::string AssigneeData::toDeclaration() const {

--- a/source/common/assignee-data.cpp
+++ b/source/common/assignee-data.cpp
@@ -48,13 +48,14 @@ AssigneeData::Builder::Builder(AssigneeData&& assignee)
 
 AssigneeData::Builder&
 AssigneeData::Builder::name(const llvm::StringRef& name) {
-  _assignee.name = name.rtrim();
+  auto trimmed = name.rtrim();
+  _assignee.name.assign(trimmed.begin(), trimmed.end());
   return *this;
 }
 
 AssigneeData::Builder& AssigneeData::Builder::type(
     const llvm::StringRef& name, bool isDefaultConstructible) {
-  _assignee.type.emplace(name, isDefaultConstructible);
+  _assignee.type.emplace(name.str(), isDefaultConstructible);
   return *this;
 }
 

--- a/source/common/assignee-data.cpp
+++ b/source/common/assignee-data.cpp
@@ -72,7 +72,7 @@ bool AssigneeData::isDefaultConstructible() const noexcept {
 }
 
 std::string AssigneeData::toAssignment(bool withType) const {
-  if (withType) {
+  if (withType && type.hasValue()) {
     assert(type.hasValue() &&
            "Requested assignee string with type, but have no type");
     return (llvm::Twine(type->name) + " " + name + " " + op).str();

--- a/source/common/definition-data.cpp
+++ b/source/common/definition-data.cpp
@@ -134,8 +134,8 @@ std::string getRewrittenText(clang::Stmt* body,
     shouldDeclare = definitionRewriter.rewriteReturnsToAssignments(*body);
   }
 
-  const auto afterBrace = body->getLocStart().getLocWithOffset(+1);
-  const auto beforeBrace = body->getLocEnd().getLocWithOffset(-1);
+  const auto afterBrace = body->getBeginLoc().getLocWithOffset(+1);
+  const auto beforeBrace = body->getEndLoc().getLocWithOffset(-1);
   const clang::SourceRange range(afterBrace, beforeBrace);
 
   auto text = withoutIndentation(rewriter.getRewrittenText(range));

--- a/source/common/definition-rewriter.cpp
+++ b/source/common/definition-rewriter.cpp
@@ -33,6 +33,7 @@
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/ExprCXX.h>
+#include <clang/AST/ParentMapContext.h>
 #include <clang/AST/Stmt.h>
 #include <clang/AST/Type.h>
 #include <clang/AST/TypeLoc.h>

--- a/source/common/definition-rewriter.cpp
+++ b/source/common/definition-rewriter.cpp
@@ -144,9 +144,9 @@ bool DefinitionRewriter::VisitTypeLoc(clang::TypeLoc typeLocation) {
 
   const auto original =
       templateType->getReplacedParameter()->desugar().getAsString();
-  const auto start = typeLocation.getLocStart();
+  const auto start = typeLocation.getBeginLoc();
   const auto end =
-      typeLocation.getLocStart().getLocWithOffset(original.length() - 1);
+      typeLocation.getBeginLoc().getLocWithOffset(original.length() - 1);
 
   const auto replacement = templateType->getReplacementType().getAsString();
   _rewriter.ReplaceText({start, end}, replacement);
@@ -218,7 +218,7 @@ void DefinitionRewriter::_rewriteMemberExpression(
     // Gobble up any kind of 'this->' statement or qualifier (e.g. super::x,
     // where 'super' is typedef for the base class, i.e. still an implicit
     // access).
-    const auto start = member.getLocStart();
+    const auto start = member.getBeginLoc();
     const auto end = member.getMemberLoc().getLocWithOffset(-1);
     _rewriter.ReplaceText({start, end}, _call.base);
   }

--- a/source/common/routines.cpp
+++ b/source/common/routines.cpp
@@ -76,7 +76,7 @@ std::string makeAbsolute(const std::string& filename) {
   const auto error = llvm::sys::fs::make_absolute(absolutePath);
   assert(!error && "Error generating absolute path");
   (void)error;
-  return absolutePath.str();
+  return absolutePath.str().str();
 }
 
 void error(const char* message) {

--- a/source/definition-search/tool-factory.cpp
+++ b/source/definition-search/tool-factory.cpp
@@ -39,8 +39,8 @@ ToolFactory::ToolFactory(const std::string& declarationFile, Query& query)
 : _declarationFile(declarationFile), _query(query) {
 }
 
-clang::FrontendAction* ToolFactory::create() {
-  return new DefinitionSearch::Action(_declarationFile, _query);
+std::unique_ptr<clang::FrontendAction> ToolFactory::create() {
+  return std::make_unique<DefinitionSearch::Action>(_declarationFile, _query);
 }
 
 }  // namespace DefinitionSearch

--- a/source/symbol-search/action.cpp
+++ b/source/symbol-search/action.cpp
@@ -108,8 +108,8 @@ bool verifyToken(const clang::Token& token) {
 clang::FileID getFileID(const Location& targetLocation,
                         clang::SourceManager& sourceManager) {
   auto& fileManager = sourceManager.getFileManager();
-  const auto* fileEntry = fileManager.getFile(targetLocation.filename);
-  if (fileEntry == nullptr || !fileEntry->isValid()) {
+  const auto fileEntry = fileManager.getFile(targetLocation.filename);
+  if (!fileEntry) {
     Routines::error("Could not find file " +
                     llvm::Twine(targetLocation.filename) +
                     " in file manager\n");
@@ -119,7 +119,7 @@ clang::FileID getFileID(const Location& targetLocation,
          "Symbol search should only run on the target TU");
 
   const auto fileID =
-      sourceManager.getOrCreateFileID(fileEntry, clang::SrcMgr::C_User);
+      sourceManager.getOrCreateFileID(*fileEntry, clang::SrcMgr::C_User);
   if (!fileID.isValid()) {
     Routines::error("Error getting file ID from file entry");
   }

--- a/source/symbol-search/action.cpp
+++ b/source/symbol-search/action.cpp
@@ -180,9 +180,8 @@ Action::Action(Location targetLocation, Query& query)
 : _query(query), _targetLocation(std::move(targetLocation)) {
 }
 
-bool Action::BeginSourceFileAction(clang::CompilerInstance& compiler,
-                                   llvm::StringRef filename) {
-  if (!super::BeginSourceFileAction(compiler, filename)) return false;
+bool Action::BeginSourceFileAction(clang::CompilerInstance& compiler) {
+  if (!super::BeginSourceFileAction(compiler)) return false;
 
   auto& sourceManager = compiler.getSourceManager();
   const clang::SourceLocation location =

--- a/source/symbol-search/macro-search.cpp
+++ b/source/symbol-search/macro-search.cpp
@@ -191,8 +191,9 @@ MacroSearch::ParameterMap MacroSearch::_createParameterMap(
     auto numberOfTokens = arguments.getArgLength(firstToken);
     clang::TokenLexer lexer(firstToken,
                             numberOfTokens,
-                            /*DisableExpansion=*/true,
-                            false, false,
+                            /* DisableMacroExpansion= */ true,
+                            /* OwnsTokens= */ false,
+                            /* IsReinject= */ false,
                             _preprocessor);
 
     llvm::SmallString<32> wholeArgument;

--- a/source/symbol-search/macro-search.cpp
+++ b/source/symbol-search/macro-search.cpp
@@ -183,16 +183,16 @@ std::string MacroSearch::_rewriteMacro(const clang::MacroInfo& info,
 MacroSearch::ParameterMap MacroSearch::_createParameterMap(
     const clang::MacroInfo& info, const clang::MacroArgs& arguments) {
   ParameterMap mapping;
-  if (info.getNumArgs() == 0) return mapping;
+  if (info.getNumParams() == 0) return mapping;
 
   unsigned number = 0;
-  for (const auto* parameter : info.args()) {
+  for (const auto* parameter : info.params()) {
     const auto* firstToken = arguments.getUnexpArgument(number);
     auto numberOfTokens = arguments.getArgLength(firstToken);
     clang::TokenLexer lexer(firstToken,
                             numberOfTokens,
                             /*DisableExpansion=*/true,
-                            false,
+                            false, false,
                             _preprocessor);
 
     llvm::SmallString<32> wholeArgument;

--- a/source/symbol-search/macro-search.cpp
+++ b/source/symbol-search/macro-search.cpp
@@ -82,8 +82,8 @@ std::string getDefinitionText(const clang::MacroInfo& info,
 void rewriteStringifiedMacroArgument(clang::Rewriter& rewriter,
                                      const clang::Token& token,
                                      const llvm::StringRef& mappedParameter) {
-  const clang::SourceRange range(token.getLocation().getLocWithOffset(-1),
-                                 token.getEndLoc());
+  const clang::SourceRange range(token.getLocation(),
+                                 token.getEndLoc().getLocWithOffset(-1));
   auto replacement = (llvm::Twine("\"") + mappedParameter + "\"").str();
   rewriter.ReplaceText(range, std::move(replacement));
 }
@@ -94,8 +94,8 @@ void rewriteSimpleMacroArgument(clang::Rewriter& rewriter,
                                 const clang::Token& token,
                                 const llvm::StringRef& mappedParameter,
                                 unsigned hashCount) {
-  const auto offset = -static_cast<int>(hashCount);
-  const clang::SourceRange range(token.getLocation().getLocWithOffset(-1),
+  const auto offset = -static_cast<int>(hashCount) - 1;
+  const clang::SourceRange range(token.getLocation(),
                                  token.getEndLoc().getLocWithOffset(offset));
   rewriter.ReplaceText(range, mappedParameter);
 }

--- a/source/symbol-search/match-handler.cpp
+++ b/source/symbol-search/match-handler.cpp
@@ -378,7 +378,7 @@ handleCallForBinaryOperator(const clang::BinaryOperator& binaryOperator,
 
   std::string name;
   if (const auto* declRefExpr = llvm::dyn_cast<clang::DeclRefExpr>(lhs)) {
-    name = declRefExpr->getDecl()->getName();
+    name = declRefExpr->getDecl()->getName().str();
   } else {
     // This may be a member expression, a function call or something else. But
     // since it's not a declaration, we can be quite safe to plop this into

--- a/source/symbol-search/match-handler.cpp
+++ b/source/symbol-search/match-handler.cpp
@@ -500,8 +500,7 @@ void decorateCallDataWithMemberBase(CallData& callData,
 
   if (auto* member = result.Nodes.getNodeAs<clang::MemberExpr>("member")) {
     const auto it = member->child_begin();
-    const clang::Expr* child = (const clang::Expr*)*it;
-    child = child->IgnoreImplicit();
+    const auto child = llvm::cast<clang::Expr>(*it)->IgnoreImplicit();
     if (!llvm::isa<clang::CXXThisExpr>(child)) {
       const char* start = bufferPointerAt(member->getBeginLoc(), result);
       const char* end = bufferPointerAt(member->getMemberLoc(), result);

--- a/source/symbol-search/tool-factory.cpp
+++ b/source/symbol-search/tool-factory.cpp
@@ -36,8 +36,8 @@ ToolFactory::ToolFactory(const Location& targetLocation, Query& query)
 : _targetLocation(targetLocation), _query(query) {
 }
 
-clang::FrontendAction* ToolFactory::create() {
-  return new SymbolSearch::Action(_targetLocation, _query);
+std::unique_ptr<clang::FrontendAction> ToolFactory::create() {
+  return std::make_unique<SymbolSearch::Action>(_targetLocation, _query);
 }
 
 }  // namespace SymbolSearch


### PR DESCRIPTION
When expanding the parameters in function-style macros, the surrounding tokens such as the parentheses in `(a)` and the braces in `{stmt}` are critical.  Eating the braces in `for (...){stmt}` can result in the first statement in `stmt` being attached to the `for` statement.

Since I'm here, I upgrade the project to built against Clang trunk, and added a library pragma for linking on Windows.